### PR TITLE
[Feat] 알림페이지 더미데이터로 채움, 모두읽기 기능추가

### DIFF
--- a/iOS-ssumgo/iOS-ssumgo/Source/Presentation/Notification/View/NotificationView.swift
+++ b/iOS-ssumgo/iOS-ssumgo/Source/Presentation/Notification/View/NotificationView.swift
@@ -11,9 +11,9 @@ struct NotificationView: View {
     
     private let rectWidth: CGFloat = 339
     
-    var notRead: Bool = false
-    var recent7Days: Bool = false
-    var recent30Days: Bool = false
+    @State var notRead: Bool = true
+    var recent7Days: Bool = true
+    var recent30Days: Bool = true
     @Environment(\.presentationMode) var presentationMode
     
     var body: some View {
@@ -48,6 +48,7 @@ struct NotificationView: View {
                                     title: "모두읽음",
                                     action: {
                                         print("모두읽음 버튼 클릭")
+                                        notRead = false
                                     },
                                     color: .sMain,
                                     font: .pretendard(.regular, size: 16),
@@ -61,7 +62,7 @@ struct NotificationView: View {
                             NotificationListView(notifications: [
                                 ("소프트웨어학부 기말 프로젝트 주제가 뭔가요?", "박**", 21, "소프트웨어학부"),
                                 ("전자정보공학부 실험 수업에서 준비해야 할 사항이 있나요?", "최**", 23, "전자정보공학부"),
-                                ("경영학부 중간고사 범위가 어떻게 되나요?", "김**", 21, "경영학부")
+                                ("컴퓨터학부 기말 프로젝트 제출 기한은 언제인가요?", "박**", 21, "컴퓨터학부")
                             ])
                             .padding(.horizontal, 23)
                             .padding(.top, 16)


### PR DESCRIPTION
# ✨ Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
close #49

<br/>

# 🍀 PR Point
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지, 주요 코드를 써주세요 -->
알림페이지 더미데이터로 채웠습니다.
모두 읽기 글자를 눌렀을때 '읽지 않음' 에 속한 알림이 사라지도록 했습니다.
```swift
CustomTextButton(
    title: "모두읽음",
    action: {
        print("모두읽음 버튼 클릭")
        notRead = false
    },
    color: .sMain,
    font: .pretendard(.regular, size: 16),
    underline: true
)
```

<br/>

# 📷 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

https://github.com/user-attachments/assets/36837a1a-d0df-49f4-839a-5fb734e2335a
